### PR TITLE
fix: sanitize pagination params

### DIFF
--- a/app/api/admin/trophies/[id]/route.ts
+++ b/app/api/admin/trophies/[id]/route.ts
@@ -8,8 +8,8 @@ function isCompetition(x: unknown): x is Competition {
   return x === 'UCL' || x === 'EUROPA';
 }
 
-function asId(param: string): string | number {
-  return /^\d+$/.test(param) ? Number(param) : param;
+function asId(param: string): string {
+  return param;
 }
 
 export async function GET(
@@ -18,7 +18,7 @@ export async function GET(
 ) {
   const id = asId(params.id);
   const t = await prisma.trophyAward.findUnique({
-    where: { id: id as any },
+    where: { id },
     include: { user: { select: { name: true } } },
   });
   if (!t) return NextResponse.json({ error: 'Not found' }, { status: 404 });
@@ -33,10 +33,6 @@ export async function GET(
   });
 }
 
-interface UpdatePayload {
-  competition?: Competition;
-  approved?: boolean;
-}
 export async function PUT(
   req: Request,
   { params }: { params: { id: string } }
@@ -71,7 +67,7 @@ export async function PUT(
   }
 
   const updated = await prisma.trophyAward.update({
-    where: { id: id as any },
+    where: { id },
     data,
     include: { user: { select: { name: true } } },
   });
@@ -91,6 +87,6 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   const id = asId(params.id);
-  await prisma.trophyAward.delete({ where: { id: id as any } });
+  await prisma.trophyAward.delete({ where: { id } });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/admin/trophies/route.ts
+++ b/app/api/admin/trophies/route.ts
@@ -16,11 +16,13 @@ function parseBool(x: string | null): boolean | undefined {
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const page = Math.max(Number(searchParams.get('page') ?? 1), 1);
-  const pageSize = Math.min(
-    Math.max(Number(searchParams.get('pageSize') ?? 20), 1),
-    100
-  );
+  const pageParam = Number(searchParams.get('page'));
+  const page = pageParam > 0 ? Math.floor(pageParam) : 1;
+
+  const pageSizeParam = Number(searchParams.get('pageSize'));
+  const pageSize = pageSizeParam > 0
+    ? Math.min(Math.floor(pageSizeParam), 100)
+    : 20;
   const userId = searchParams.get('userId') ?? undefined;
   const comp = searchParams.get('competition');
   const approved = parseBool(searchParams.get('approved'));


### PR DESCRIPTION
## Summary
- handle invalid `page` and `pageSize` values in admin trophies API
- remove `any` casts from individual trophy admin API

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: missing fields and undefined session.user)*

------
https://chatgpt.com/codex/tasks/task_e_68bc24f0bfec83289cd3bdee82cb4b46